### PR TITLE
feat: 🚧 modify(수정) 기능 완료 => TodoAddForm 컴포넌트를 TodoForm 컴포넌트로 수정 후 해당 …

### DIFF
--- a/src/components/TodoCard.ts
+++ b/src/components/TodoCard.ts
@@ -1,3 +1,5 @@
+import TodoForm from './TodoForm';
+
 import GlobalModal from '@/components/GlobalModal';
 import ITodo from '@/interface/ITodo';
 import { $$ } from '@/utils/dom';
@@ -39,6 +41,19 @@ export default class TodoCard {
     });
   };
 
+  handleOnDbClick = () => {
+    this.element?.addEventListener('dblclick', () => {
+      const todoForm = new TodoForm({
+        title: this.title,
+        content: this.content,
+        status: this.status,
+        type: 'modify',
+      });
+      this.element!.outerHTML = todoForm.render();
+      todoForm.registerEventListener();
+    });
+  };
+
   handleDeleteTodo = () => {
     // data 삭제는 실제 데이터 사용할때.. 적용
     // view 에서 해당 카드 삭제
@@ -47,7 +62,6 @@ export default class TodoCard {
 
   handleMouseOver = () => {
     this.element?.addEventListener('mouseover', e => {
-      console.log(this.element);
       const target = e.target as HTMLElement;
       if (target.classList.contains('card__delete--img')) {
         this.element?.classList.add('todo-delete-border');
@@ -69,6 +83,7 @@ export default class TodoCard {
     this.handleMouseOver();
     this.handleMouseOut();
     this.handleOnClick();
+    this.handleOnDbClick();
   };
 
   render = () => {

--- a/src/components/TodoColumn.ts
+++ b/src/components/TodoColumn.ts
@@ -1,4 +1,4 @@
-import TodoAddForm from '@/components/TodoAddForm';
+import TodoForm from '@/components/TodoForm';
 import IColumn from '@/interface/IColumn';
 import { $$ } from '@/utils/dom';
 
@@ -57,7 +57,10 @@ export default class TodoColumn {
           return;
         }
 
-        const newAddForm = new TodoAddForm(this.element, this.addCount);
+        const newAddForm = new TodoForm(
+          { status: this.title, type: 'add' },
+          this.addCount,
+        );
         this.element
           ?.querySelector('.column')!
           .insertAdjacentHTML('afterend', newAddForm.render());
@@ -113,7 +116,7 @@ export default class TodoColumn {
 
   render = () => {
     return /* html */ `
-    <div class="column-list" id="${this.id}">
+    <div class="column-list" id="${this.id}" data-column-status="${this.title}">
       <nav class="column">
           <div class="column__left">
               <div class="column__title">${this.title}</div>

--- a/src/components/TodoForm.ts
+++ b/src/components/TodoForm.ts
@@ -1,12 +1,10 @@
 import TodoCard from './TodoCard';
 
-import { $$ } from '@/utils/dom';
+import { $, $$ } from '@/utils/dom';
 import { newID } from '@/utils/util';
 
-export default class TodoAddForm {
+export default class TodoForm {
   id: string;
-
-  parentElement: HTMLElement | null;
 
   element: HTMLElement | null;
 
@@ -14,21 +12,40 @@ export default class TodoAddForm {
 
   content: string;
 
-  addCount: () => void;
+  status: string;
 
-  constructor(parentElement: HTMLElement | null, addCount: () => void) {
+  type: string;
+
+  addCount?: () => void;
+
+  constructor(
+    state: { title?: string; content?: string; status: string; type: string },
+    addCount?: () => void,
+  ) {
     this.id = newID();
-    this.parentElement = parentElement;
     this.element = null;
-    this.title = '';
-    this.content = '';
+    this.title = state.title || '';
+    this.content = state.content || '';
+    this.status = state.status;
+    this.type = state.type;
     this.addCount = addCount;
   }
+
+  setInitValue = () => {
+    if (this.content) {
+      const $textArea = this.element?.querySelector(
+        '.input-content',
+      ) as HTMLTextAreaElement;
+
+      $textArea!.value = this.content;
+    }
+  };
 
   checkValue = () => {
     const registerButton = this.element?.querySelector(
       '.input--register',
     ) as HTMLButtonElement;
+    console.log(this.title, this.content);
 
     if (this.title && this.content) {
       registerButton.disabled = false;
@@ -67,31 +84,36 @@ export default class TodoAddForm {
         this.element?.remove();
       } else if (target.classList.contains('input--register')) {
         // set TodoCard
+        const columnElement = $(`[data-column-status=${this.status}]`);
+
         const newCard = new TodoCard({
           id: this.id,
           title: this.title,
           content: this.content,
-          status: 'todo',
+          status: this.status,
           date: new Date().toString(),
         });
+
         // Column 뒤에 붙이기
-        this.parentElement
+        columnElement
           ?.querySelector('.column')
           ?.insertAdjacentHTML('afterend', newCard.render());
         newCard.registerEventListener();
-        // TodoAddForm remove
+        // TodoForm remove
 
         this.element?.remove();
         // set Action
 
         // add count
-        this.addCount();
+        this.addCount?.();
       }
     });
   };
 
   registerEventListener = () => {
     this.element = $$(this.id);
+    this.setInitValue();
+    this.checkValue();
     this.handleOnChangeValue();
     this.handleOnClick();
   };
@@ -99,11 +121,13 @@ export default class TodoAddForm {
   render = () => {
     return /* html */ `
         <article class="input-wrapper todo-border" id="${this.id}">
-            <input class="input-title" placeholder="제목을 입력하세요" />
+            <input class="input-title" placeholder="제목을 입력하세요"
+            value=${this.title}>
             <textarea class="input-content" placeholder="내용을 입력하세요" maxlength ='500'></textarea>
             <div class="input-button-wrapper">
                 <button class="input__button input--cancel" type="button">취소</button>
-                <button class="input__button input--register bg-sky-blue" type="button" disabled>등록</button>
+                <button class="input__button input--register bg-sky-blue" type="button" disabled>
+                ${this.type === 'add' ? '등록' : '수정'}</button>
             </div>
         </article>
     `;


### PR DESCRIPTION
close #45 #46 #47 

…클래스 재사용하는 방식으로 구현

1. column에 data-column-status 속성을 심어 놓고 todo 생성시 해당 값을 status로 갖도록

2. TodoForm 생성시 객체 형태로 데이터 받도록 수정, addCount 함수는 수정폼일때는 따로 받을 필요없으므로 우선 옵셔널 연산자로 선택

3. TodoCard 클래스 내에선 더블클릭 이벤트리스너 함수 구현.

* 수정할때와 추가할때 모두 TodoForm 클래스를 사용한 점에서 좋았지만, 타입을 현재 옵셔널로 너무 남발해서 보기가 안좋다.. 수정을 위한 타입, 추가를 위한 투두 타입을 만드는게 좋아보인다?