### PR TITLE
♻️ 드래그앤드롭시 에러 처리 수정

### DIFF
--- a/client/src/components/TodoForm.ts
+++ b/client/src/components/TodoForm.ts
@@ -123,7 +123,7 @@ export default class TodoForm {
       const $registerButton = this.element.querySelector('.input--register');
       if ($registerButton) {
         $registerButton.addEventListener('click', async () => {
-          const $columnElement = $$(this.columnId);
+          const $columnElement = $$(this.uuid)?.parentElement;
 
           const cardData = {
             columnId: this.columnId,
@@ -183,10 +183,11 @@ export default class TodoForm {
   };
 
   render = () => {
+    console.log(this.title);
     return /* html */ `
         <article class="input-wrapper todo-border" id="${this.uuid}">
-            <input class="input-title" placeholder="제목을 입력하세요"
-            value=${this.title}>
+            <input type="text" class="input-title" placeholder="제목을 입력하세요"
+            value="${this.title}">
             <textarea class="input-content" placeholder="내용을 입력하세요" maxlength ='500'></textarea>
             <div class="input-button-wrapper">
                 <button class="input__button input--cancel" type="button">취소</button>

--- a/client/src/style/index.scss
+++ b/client/src/style/index.scss
@@ -25,5 +25,6 @@ body {
 
 #root {
   height: 100vh;
+  user-select: none;
 }
 

--- a/client/src/utils/eventDragHandler.js
+++ b/client/src/utils/eventDragHandler.js
@@ -6,7 +6,6 @@ import { getToday } from '@/utils/date';
 import { $$ } from '@/utils/dom';
 
 const dragElement = $$('drag');
-const rootElement = $$('root');
 let copyElement = null; // 마우스를 따라다니는 복사된 카드
 let shadowElement = null; // 잔상카드
 let status = '';
@@ -32,7 +31,7 @@ const isBefore = (element1, element2) => {
 };
 
 const handleBodyMouseDown = () => {
-  rootElement.addEventListener('mousedown', e => {
+  document.body.addEventListener('mousedown', e => {
     const target = e.target;
     const clickedCardElement = target.closest("[data-drag='true']");
 
@@ -64,7 +63,7 @@ const handleBodyMouseDown = () => {
 };
 
 const handleBodyMouseMove = () => {
-  rootElement.addEventListener('mousemove', e => {
+  document.body.addEventListener('mousemove', e => {
     if (!copyElement) return;
 
     const { screenX, screenY } = e;
@@ -96,6 +95,7 @@ const handleBodyMouseMove = () => {
       return;
     }
 
+    // shadowElement를 이동한 칼럼에 연결해줘야 한다.
     if (isBefore(shadowElement, cardElement)) {
       cardElement.parentNode.insertBefore(shadowElement, cardElement);
     } else if (cardElement.parentNode) {
@@ -128,7 +128,7 @@ const handleDataUpdate = async (uuid, title) => {
 };
 
 const handleBodyMouseUp = () => {
-  rootElement.addEventListener('mouseup', () => {
+  document.body.addEventListener('mouseup', () => {
     if (shadowElement) {
       shadowElement.classList.remove('spectrum');
     }


### PR DESCRIPTION
1. 드래그시 모든 텍스트들 드래그되는 문제 user-select 속성으로 막기.

2. 드래그이후 해당 카드를 수정 시 해당 카드가 가지고 있는 columnId로 인해 이전 칼럼으로 이동되는 현상. => columId를 모두 걷어내려고 했지만.. 수정할 부분이 많다고 생각해 우선 수정하는 카드의 칼럼을 찾는 로직만 바꿈. 해당 카드 uuid로 찾고 parentElement로 부모 엘리먼트 찾기.

3. drag 관련 부분 body element로 달기.